### PR TITLE
Allow for Hot Reload Inside Containers

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -22,4 +22,4 @@ USER www
 
 EXPOSE 5000
 
-CMD [ "gunicorn", "-w", "4", "--bind", "0.0.0.0:5000", "wsgi", "-t 600"]
+CMD [ "gunicorn", "-w", "4", "--bind", "0.0.0.0:5000", "wsgi", "-t 600", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       MONGODB_USERNAME: flaskuser
       MONGODB_PASSWORD: your_mongodb_password
       MONGODB_HOSTNAME: mongodb
-#    volumes:
-#      - appdata:/var/www
+    volumes:
+      - ./app/:/var/www
     depends_on:
       - mongodb
     networks:


### PR DESCRIPTION
This PR allows for local development to auto-reload the code running inside the flask/webserver containers so that containers don't need to be destroyed and rebuilt as often. This should increase development velocity as well as a step towards being able to run tests quicker locally.