### PR TITLE
Move from api tokens to API keys that are included in the header

### DIFF
--- a/app/application/routes.py
+++ b/app/application/routes.py
@@ -5,13 +5,15 @@ from . import registry
 
 @app.route('/')
 def index():
-    return jsonify(
-        status=True,
-        message='Welcome to the ULI Registry app!'
-    )
+  """This method returns a one line home page"""
+  return jsonify(
+      status=True,
+      message='Welcome to the ULI Registry app!'
+  )
 
 @app.route('/query', methods=['POST'])
 def licensee():
+  """This method is not often used but can tell you if a ULI exists for a member without creating one"""
   record = json.loads(request.data)
   #license info optional
   if record.get('LicenseInfo') is None:
@@ -47,6 +49,7 @@ def licensee():
 
 @app.route('/register', methods=['POST'])
 def registerLicensee():
+  """This method is used for registering a new ULI if one does exist"""
   record = json.loads(request.data)
   if record.get('LicenseInfo') is None:
      record['LicenseInfo'] = ""
@@ -85,10 +88,11 @@ def registerLicensee():
 
 
 ### ADMIN METHODS ###
-API_KEY = '_api_key' #TODO: add real admin tokens
+API_KEY = '_api_key' #TODO: add real admin api keys/ tokens
 
 @app.route('/generate_licensees', methods=['POST'])
 def generateLicensees():
+  """This method is primarily used for testing purposes and generates X number of fake licensees"""
   post_data = request.get_json(force=True)
   api_key=request.headers.get('X-API-KEY')
   num_licensees = post_data.get('NumLicensees', None)
@@ -140,7 +144,7 @@ def getLicensee():
   
 @app.route('/remove_licensee', methods=['DELETE'])
 def removeLicensee():
-  """This method is primarily used for testing purposes and requires a token"""
+  """This method is primarily used for testing purposes and requires an api key"""
   post_data = request.get_json(force=True)
   api_key=request.headers.get('X-API-KEY')
   uli = post_data.get('uli', None)

--- a/app/application/routes.py
+++ b/app/application/routes.py
@@ -85,18 +85,18 @@ def registerLicensee():
 
 
 ### ADMIN METHODS ###
-API_KEY = '_admin_token' #TODO: add real admin tokens
+API_KEY = '_api_key' #TODO: add real admin tokens
 
 @app.route('/generate_licensees', methods=['POST'])
 def generateLicensees():
   post_data = request.get_json(force=True)
-  api_key = post_data.get('token', None)
+  api_key=request.headers.get('X-API-KEY')
   num_licensees = post_data.get('NumLicensees', None)
   
   if api_key is None or api_key != API_KEY:
     return jsonify(
         status=False,
-        message='Invalid Access Token!'
+        message='Invalid API Key!'
     ), 403
 
   num_licensees = registry.generate_licensees(num_licensees)
@@ -109,14 +109,14 @@ def generateLicensees():
 @app.route('/find_licensee', methods=['POST'])
 def getLicensee():
   """This method fetches ULIs by Id"""
+  api_key=request.headers.get('X-API-KEY')
   post_data = request.get_json(force=True)
-  api_key = post_data.get('token', None)
   uli = post_data.get('uli', None)
 
   if api_key is None or api_key != API_KEY:
     return jsonify(
         status=False,
-        message='Invalid Access Token!'
+        message='Invalid API Key!'
     ), 403
 
   if uli is None:
@@ -142,14 +142,13 @@ def getLicensee():
 def removeLicensee():
   """This method is primarily used for testing purposes and requires a token"""
   post_data = request.get_json(force=True)
-  
-  api_key = post_data.get('token', None)
+  api_key=request.headers.get('X-API-KEY')
   uli = post_data.get('uli', None)
 
   if api_key is None or api_key != API_KEY:
     return jsonify(
         status=False,
-        message='Invalid Access Token!'
+        message='Invalid API Key!'
     ), 403
 
   if uli is None:

--- a/app/application/static/swagger.yaml
+++ b/app/application/static/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     This is a prototype version of a centralized ULI server.  You can find out more about ULI at
     [https://reso.org](https://reso.org). For this proof of concept, you can use the api
-    key `_admin_token` to test the authorization filters.
+    key `_api_key` to test the authorization filters.
   version: 1.0.0
   title: Centralized Universal Licensee Identification Service
   termsOfService: >-
@@ -19,6 +19,8 @@ tags:
   - name: registration
     description: Registration and Query endpoints
   - name: admin
+    security:
+      - ApiKeyAuth: []
     description: Administrative Functions like data generation, delete
 schemes:
   - http
@@ -73,6 +75,8 @@ paths:
         - admin
       summary: Verifies if a ULI is in the registry
       description: ''
+      security:
+        - ApiKeyAuth: []
       produces:
         - application/json
       consumes:
@@ -95,6 +99,8 @@ paths:
         - admin
       summary: Generates fake licensee data
       description: ''
+      security:
+        - ApiKeyAuth: []
       produces:
         - application/json
       consumes:
@@ -117,6 +123,8 @@ paths:
         - admin
       summary: Removes a ULI
       description: ''
+      security:
+        - ApiKeyAuth: []
       produces:
         - application/json
       consumes:
@@ -133,18 +141,18 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/DeleteResponse'
-# securityDefinitions:
-#   api_key:
-#     type: apiKey
-#     name: token
-#     in: header
+securityDefinitions:
+    ApiKeyAuth:        # arbitrary name for the security scheme
+      type: apiKey
+      in: header       # can be "header", "query" or "cookie"
+      name: X-API-KEY  # name of the header, query parameter or cookie
 definitions:
   AdminFindRequest:
     type: object
     properties:
       token:
         type: string
-        example: _admin_token
+        example: _api_key
       uli:
         type: string
         example: 6032f18a79272c4ef28d4119      
@@ -184,7 +192,7 @@ definitions:
     properties:
       token:
         type: string
-        example: _admin_token
+        example: _api_key
       uli:
         type: string
         example: 602c6bbead2cef1872ea1e8d      
@@ -201,7 +209,7 @@ definitions:
     properties:
       token:
         type: string
-        example: _admin_token
+        example: _api_key
       NumLicensees:
         type: int
         example: 100      

--- a/app/application/static/swagger.yaml
+++ b/app/application/static/swagger.yaml
@@ -150,9 +150,6 @@ definitions:
   AdminFindRequest:
     type: object
     properties:
-      token:
-        type: string
-        example: _api_key
       uli:
         type: string
         example: 6032f18a79272c4ef28d4119      
@@ -190,9 +187,6 @@ definitions:
   DeleteRequest:
     type: object
     properties:
-      token:
-        type: string
-        example: _api_key
       uli:
         type: string
         example: 602c6bbead2cef1872ea1e8d      
@@ -207,9 +201,6 @@ definitions:
   GenerateDataRequest:
     type: object
     properties:
-      token:
-        type: string
-        example: _api_key
       NumLicensees:
         type: int
         example: 100      

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -76,65 +76,64 @@ def test_query_ULI_not_found(test_client):
 ############ Admin Functions #################
 ##############################################
 
-FAKE_ADMIN_TOKEN = '_admin_token' #TODO: add real admin tokens
-FAKE_GENERATION_RECORD = {   
-    "token": FAKE_ADMIN_TOKEN,
-    "NumLicensees": 100
-}
-FAKE_FIND_ULI_BODY = {
-    "token" :"_admin_token",
-    "uli" : "9999999999"
-}
-FAKE_REMOVE_ULI_BODY = {
-    "token" :"_admin_token",
-    "uli" : "9999999999"
-}
+FAKE_API_KEY = '_api_key' #TODO: add real admin tokens
+FAKE_GENERATION_RECORD = {"NumLicensees": 100}
+FAKE_FIND_ULI_BODY = { "uli" : "9999999999" }
+FAKE_REMOVE_ULI_BODY = {"uli" : "9999999999" }
+ADMIN_HEADER = {'Content-Type': 'application/json', 'X-API-KEY': FAKE_API_KEY}
 
 
 def test_find_ULI(test_client):
-  response = test_client.post('/register', data=json.dumps(FAKE_TESTING_RECORD), follow_redirects=True)
+  response = test_client.post('/register',  data=json.dumps(FAKE_TESTING_RECORD), follow_redirects=True)
   response_data = json.loads(response.data)
-  FIND_ULI_BODY = {
-    "token" :"_admin_token",
-    "uli" : response_data["uli"]
-    }
-  response = test_client.post('/find_licensee', data=json.dumps(FIND_ULI_BODY), follow_redirects=True)
+  FIND_ULI_BODY = {"uli" : response_data["uli"]}
+  response = test_client.post('/find_licensee', headers = ADMIN_HEADER, data=json.dumps(FIND_ULI_BODY), follow_redirects=True)
  
   assert response.status_code == 200
 
-
 def test_find_ULI_not_found(test_client):
-  response = test_client.post('/find_licensee', data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
+  response = test_client.post('/find_licensee', headers = ADMIN_HEADER, data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
  
   assert response.status_code == 404
 
+def test_require_apikey_find_uli(test_client):
+  response = test_client.post('/find_licensee', data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
+
+  assert response.status_code == 403
+
 def test_admin_generate_licensees(test_client):
-  response = test_client.post('/generate_licensees', data=json.dumps(FAKE_GENERATION_RECORD), follow_redirects=True)
+  response = test_client.post('/generate_licensees', headers = ADMIN_HEADER, data=json.dumps(FAKE_GENERATION_RECORD), follow_redirects=True)
   response_data = json.loads(response.data)
 
   assert response.status_code == 201
   assert b"100 generated!" in response.data
   assert response_data["status"] is True
 
+def test_require_apikey_generate_licensee(test_client):
+  response = test_client.post('/generate_licensees', data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
+  
+  assert response.status_code == 403
+
 def test_remove_licensee(test_client):
-  response = test_client.post('/register', data=json.dumps(FAKE_TESTING_RECORD), follow_redirects=True)
+  response = test_client.post('/register', headers = ADMIN_HEADER, data=json.dumps(FAKE_TESTING_RECORD), follow_redirects=True)
   response_data = json.loads(response.data)
-  REMOVE_ULI_BODY = {
-    "token" :"_admin_token",
-    "uli" : response_data["uli"]
-  }
+  REMOVE_ULI_BODY = {"uli" : response_data["uli"]}
 
-  response = test_client.delete('/remove_licensee', data=json.dumps(REMOVE_ULI_BODY), follow_redirects=True)
-
+  response = test_client.delete('/remove_licensee', headers = ADMIN_HEADER, data=json.dumps(REMOVE_ULI_BODY), follow_redirects=True)
   assert response.status_code == 200
   assert b"deleted!" in response.data
 
 
 def test_remove_licensee_not_found(test_client):
-  response = test_client.delete('/remove_licensee', data=json.dumps(FAKE_REMOVE_ULI_BODY), follow_redirects=True)
-
+  response = test_client.delete('/remove_licensee', headers = ADMIN_HEADER, data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
   assert response.status_code == 404
   assert b"not found!" in response.data
+
+def test_require_apikey_remove_licensee(test_client):
+  response = test_client.delete('/remove_licensee', data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)
+  assert response.status_code == 403
+
+
 
 
 

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -76,7 +76,7 @@ def test_query_ULI_not_found(test_client):
 ############ Admin Functions #################
 ##############################################
 
-FAKE_API_KEY = '_api_key' #TODO: add real admin tokens
+FAKE_API_KEY = '_api_key' #TODO: add real admin keys/tokens
 FAKE_GENERATION_RECORD = {"NumLicensees": 100}
 FAKE_FIND_ULI_BODY = { "uli" : "9999999999" }
 FAKE_REMOVE_ULI_BODY = {"uli" : "9999999999" }
@@ -114,15 +114,15 @@ def test_require_apikey_generate_licensee(test_client):
   
   assert response.status_code == 403
 
+
 def test_remove_licensee(test_client):
   response = test_client.post('/register', headers = ADMIN_HEADER, data=json.dumps(FAKE_TESTING_RECORD), follow_redirects=True)
   response_data = json.loads(response.data)
   REMOVE_ULI_BODY = {"uli" : response_data["uli"]}
-
   response = test_client.delete('/remove_licensee', headers = ADMIN_HEADER, data=json.dumps(REMOVE_ULI_BODY), follow_redirects=True)
+  
   assert response.status_code == 200
   assert b"deleted!" in response.data
-
 
 def test_remove_licensee_not_found(test_client):
   response = test_client.delete('/remove_licensee', headers = ADMIN_HEADER, data=json.dumps(FAKE_FIND_ULI_BODY), follow_redirects=True)


### PR DESCRIPTION
This PR removes tokens from being sent in the body and instead as X-API-KEY in the header. This is required for all admin functions currently. This PR also documents this authentication in swagger.